### PR TITLE
Add missing keyed instances from lens

### DIFF
--- a/keys.cabal
+++ b/keys.cabal
@@ -26,9 +26,11 @@ library
     comonad              >= 4       && < 5,
     containers           >= 0.3     && < 0.6,
     free                 >= 4       && < 5,
+    hashable             >= 1.1.2.3 && < 1.3,
     semigroupoids        >= 4       && < 5,
     semigroups           >= 0.8.3.1 && < 1,
-    transformers         >= 0.2     && < 0.5
+    transformers         >= 0.2     && < 0.5,
+    unordered-containers >= 0.2     && < 0.3
 
   exposed-modules:
     Data.Key


### PR DESCRIPTION
This adds instances that are defined in `Control.Lens.Indexed` from `lens`, but not in `keys` (namely, for `(,) k`, `HashMap`, and `Maybe`).

I can't currently add all the instances for `Backwards` and `Reverse` since they're not `Foldable1` and `Traversable1` instances in `semigroupoids` currently, so I'll hold off on them.