### PR TITLE
bump version

### DIFF
--- a/keys.cabal
+++ b/keys.cabal
@@ -27,7 +27,7 @@ library
     containers           >= 0.3     && < 0.6,
     free                 >= 4       && < 5,
     hashable             >= 1.1.2.3 && < 1.3,
-    semigroupoids        >= 4       && < 5,
+    semigroupoids        >= 4       && < 5.1,
     semigroups           >= 0.8.3.1 && < 1,
     transformers         >= 0.2     && < 0.5,
     unordered-containers >= 0.2     && < 0.3


### PR DESCRIPTION
I do not know what is the maximum `semigroupoids` version which works with `keys` so I bumped it by `2%`.
We need a bot to optimise upper bounds for packages. 