### PR TITLE
Update unordered-containers version lock

### DIFF
--- a/keys.cabal
+++ b/keys.cabal
@@ -30,7 +30,7 @@ library
     semigroupoids        >= 4       && < 6,
     semigroups           >= 0.8.3.1 && < 1,
     transformers         >= 0.2     && < 0.5,
-    unordered-containers >= 0.2     && < 0.3
+    unordered-containers >= 0.2.4   && < 0.3
 
   exposed-modules:
     Data.Key


### PR DESCRIPTION
Bumping due to missing `Data.HashMap.Lazy.mapWithKey`