### PR TITLE
bump lower bound for semigroupoids for Foldable1 `(,) a` instance

### DIFF
--- a/keys.cabal
+++ b/keys.cabal
@@ -27,7 +27,7 @@ library
     containers           >= 0.3     && < 0.6,
     free                 >= 4       && < 5,
     hashable             >= 1.1.2.3 && < 1.3,
-    semigroupoids        >= 4       && < 6,
+    semigroupoids        >= 4.2     && < 6,
     semigroups           >= 0.8.3.1 && < 1,
     transformers         >= 0.2     && < 0.6,
     transformers-compat  >= 0.3     && < 1,


### PR DESCRIPTION
I was getting this error when my build was pulling in version `4.0.4` of `semigroupoids`:

```
src/Data/Key.hs:841:10:
    No instance for (Foldable1 ((,) k))
      arising from the superclasses of an instance declaration
    In the instance declaration for ‘FoldableWithKey1 ((,) k)’

src/Data/Key.hs:847:10:
    No instance for (Foldable1 ((,) k))
      arising from the superclasses of an instance declaration
    In the instance declaration for ‘TraversableWithKey1 ((,) k)’
```

Earliest version of `semigroupoids` that i could find with that instance is `4.2`