### PR TITLE
Allow base-orphans-0.6 for ghc<8

### DIFF
--- a/keys.cabal
+++ b/keys.cabal
@@ -44,15 +44,15 @@ library
     transformers-compat  >= 0.3     && < 1,
     unordered-containers >= 0.2.4   && < 0.3
 
-  if impl(ghc < 7.10)
+  if !impl(ghc >= 7.10)
     build-depends: void >= 0.4 && < 0.8
 
   if impl(ghc < 7.6)
     -- GHC.Generics lived in ghc-prim initially
     build-depends: ghc-prim == 0.2.*
 
-  if impl(ghc < 8)
-    build-depends: base-orphans >= 0.5.4 && < 0.6
+  if !impl(ghc >= 8.0)
+    build-depends: base-orphans >= 0.5.4 && < 0.7
 
   exposed-modules:
     Data.Key


### PR DESCRIPTION
It would be more correct to have `if !impl (ghc >= 8.0)`, but this is smallest possible change.