### PR TITLE
Allow void-0.8

### DIFF
--- a/keys.cabal
+++ b/keys.cabal
@@ -53,7 +53,7 @@ library
     unordered-containers >= 0.2.4   && < 0.3
 
   if !impl(ghc >= 7.10)
-    build-depends: void >= 0.4 && < 0.8
+    build-depends: void >= 0.4 && < 0.9
 
   if impl(ghc < 7.6)
     -- GHC.Generics lived in ghc-prim initially


### PR DESCRIPTION
AFAICS, this is the only acme-kmett package, which has `void <0.8` bound. Everything else has `< 1`; should we change here to `< 1` too?